### PR TITLE
Add support for a differing payee in DiGA invoices

### DIFF
--- a/src/main/schematron/dre0.sch
+++ b/src/main/schematron/dre0.sch
@@ -54,12 +54,6 @@
             <assert id="DRE0-AHTA-2" test="matches(normalize-space(ram:BuyerTradeParty/ram:ID[@schemeID = 'IK']), '^\d{9}$')"
             >Eine DiGA-Rechnung muß das Institutionskennzeichen (IK) einer Krankenkasse mit exakt neun Ziffern enthalten.</assert>
         </rule>
-        <rule context="ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:ID[@schemeID = 'IK_Zahlungsempfänger']">
-            <assert id="DRE0-AHTA-3" test="matches(normalize-space(.), '^\d{9}$')"
-            >Das Institutionskennzeichen (IK) eines abweichenden Zahlungsempfängers muss exakt neun Ziffern haben.</assert>
-            <assert id="DRE0-AHTA-4" test="normalize-space(.) != normalize-space(../ram:ID[@schemeID = 'IK'])"
-            >Das Institutionskennzeichen (IK) eines abweichenden Zahlungsempfängers muss vom IK des DiGA-Herstellers verschieden sein.</assert>
-        </rule>
         <rule context="ram:ApplicableHeaderTradeSettlement">
             <assert id="DRE0-AHTS-1" test="not(ram:TaxCurrencyCode) or normalize-space(ram:TaxCurrencyCode) = 'EUR'"
             >Eine DiGA-Rechnung muß den Mehrwertsteuerbetrag in Euro (EUR) enthalten.</assert>
@@ -67,10 +61,24 @@
             >Eine DiGA-Rechnung muß den Rechnungsbetrag in Euro (EUR) enthalten.</assert>
             <assert id="DRE0-AHTS-3" test="normalize-space(ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount[@currencyID = 'EUR']) != ''"
             >Eine DiGA-Rechnung muß den Mehrwertsteuerbetrag in Euro (EUR) enthalten.</assert>
-            <assert id="DRE0-AHTS-4" test="count(ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount/ram:IBANID) = 1"
-            >Eine DiGA-Rechnung muß genau eine IBAN enthalten.</assert>
-            <assert id="DRE0-AHTS-5" test="count(ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID) = 1"
-            >Eine DiGA-Rechnung muß genau eine BICID enthalten.</assert>
+        </rule>
+        <rule context="ram:CreditorReferenceID[@schemeID = 'IK']">
+            <assert id="DRE0-CRID-1" test="matches(normalize-space(.), '^\d{9}$')"
+            >Das Institutionskennzeichen (IK) eines abweichenden Zahlungsempfängers muss exakt neun Ziffern haben.</assert>
+            <assert id="DRE0-CRID-2" test="normalize-space(.) != normalize-space(/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:ID[@schemeID = 'IK'])"
+            >Das Institutionskennzeichen (IK) eines abweichenden Zahlungsempfängers muss vom IK des DiGA-Herstellers verschieden sein.</assert>
+        </rule>
+        <rule context="ram:SpecifiedTradeSettlementPaymentMeans">
+            <assert id="DRE0-AHTS-4" test="count(ram:ApplicableTradeSettlementFinancialCard) = 0"
+            >Eine DiGA-Rechnung darf keine Informationen zur Kartenzahlung enthalten.</assert>
+            <assert id="DRE0-AHTS-5" test="count(ram:PayerPartyDebtorFinancialAccount) = 0"
+            >Eine DiGA-Rechnung darf keine Informationen zum Konto des Debitors enthalten.</assert>
+            <assert id="DRE0-AHTS-6" test="count(ram:PayeePartyCreditorFinancialAccount) = 0"
+            >Eine DiGA-Rechnung darf keine Informationen zum Konto des Kreditors enthalten.</assert>
+            <assert id="DRE0-AHTS-7" test="count(ram:PayerSpecifiedDebtorFinancialInstitution) = 0"
+            >Eine DiGA-Rechnung darf keine Informationen zur Bank des Debitors enthalten.</assert>
+            <assert id="DRE0-AHTS-8" test="count(ram:PayeeSpecifiedCreditorFinancialInstitution) = 0"
+            >Eine DiGA-Rechnung darf keine Informationen zur Bank des Kreditors enthalten.</assert>
         </rule>
     </pattern>
 </schema>

--- a/src/main/schematron/dre0.sch
+++ b/src/main/schematron/dre0.sch
@@ -54,6 +54,12 @@
             <assert id="DRE0-AHTA-2" test="matches(normalize-space(ram:BuyerTradeParty/ram:ID[@schemeID = 'IK']), '^\d{9}$')"
             >Eine DiGA-Rechnung muß das Institutionskennzeichen (IK) einer Krankenkasse mit exakt neun Ziffern enthalten.</assert>
         </rule>
+        <rule context="ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:ID[@schemeID = 'IK_Zahlungsempfänger']">
+            <assert id="DRE0-AHTA-3" test="matches(normalize-space(.), '^\d{9}$')"
+            >Das Institutionskennzeichen (IK) eines abweichenden Zahlungsempfängers muss exakt neun Ziffern haben.</assert>
+            <assert id="DRE0-AHTA-4" test="normalize-space(.) != normalize-space(../ram:ID[@schemeID = 'IK'])"
+            >Das Institutionskennzeichen (IK) eines abweichenden Zahlungsempfängers muss vom IK des DiGA-Herstellers verschieden sein.</assert>
+        </rule>
         <rule context="ram:ApplicableHeaderTradeSettlement">
             <assert id="DRE0-AHTS-1" test="not(ram:TaxCurrencyCode) or normalize-space(ram:TaxCurrencyCode) = 'EUR'"
             >Eine DiGA-Rechnung muß den Mehrwertsteuerbetrag in Euro (EUR) enthalten.</assert>
@@ -61,6 +67,10 @@
             >Eine DiGA-Rechnung muß den Rechnungsbetrag in Euro (EUR) enthalten.</assert>
             <assert id="DRE0-AHTS-3" test="normalize-space(ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount[@currencyID = 'EUR']) != ''"
             >Eine DiGA-Rechnung muß den Mehrwertsteuerbetrag in Euro (EUR) enthalten.</assert>
+            <assert id="DRE0-AHTS-4" test="count(ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount/ram:IBANID) = 1"
+            >Eine DiGA-Rechnung muß genau eine IBAN enthalten.</assert>
+            <assert id="DRE0-AHTS-5" test="count(ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID) = 1"
+            >Eine DiGA-Rechnung muß genau eine BICID enthalten.</assert>
         </rule>
     </pattern>
 </schema>

--- a/src/main/schematron/dre0.sch
+++ b/src/main/schematron/dre0.sch
@@ -69,15 +69,15 @@
             >Das Institutionskennzeichen (IK) eines abweichenden Zahlungsempfängers muss vom IK des DiGA-Herstellers verschieden sein.</assert>
         </rule>
         <rule context="ram:SpecifiedTradeSettlementPaymentMeans">
-            <assert id="DRE0-AHTS-4" test="count(ram:ApplicableTradeSettlementFinancialCard) = 0"
+            <assert id="DRE0-AHTS-4" test="not(ram:ApplicableTradeSettlementFinancialCard)"
             >Eine DiGA-Rechnung darf keine Informationen zur Kartenzahlung enthalten.</assert>
-            <assert id="DRE0-AHTS-5" test="count(ram:PayerPartyDebtorFinancialAccount) = 0"
+            <assert id="DRE0-AHTS-5" test="not(ram:PayerPartyDebtorFinancialAccount)"
             >Eine DiGA-Rechnung darf keine Informationen zum Konto des Debitors enthalten.</assert>
-            <assert id="DRE0-AHTS-6" test="count(ram:PayeePartyCreditorFinancialAccount) = 0"
+            <assert id="DRE0-AHTS-6" test="not(ram:PayeePartyCreditorFinancialAccount)"
             >Eine DiGA-Rechnung darf keine Informationen zum Konto des Kreditors enthalten.</assert>
-            <assert id="DRE0-AHTS-7" test="count(ram:PayerSpecifiedDebtorFinancialInstitution) = 0"
+            <assert id="DRE0-AHTS-7" test="not(ram:PayerSpecifiedDebtorFinancialInstitution)"
             >Eine DiGA-Rechnung darf keine Informationen zur Bank des Debitors enthalten.</assert>
-            <assert id="DRE0-AHTS-8" test="count(ram:PayeeSpecifiedCreditorFinancialInstitution) = 0"
+            <assert id="DRE0-AHTS-8" test="not(ram:PayeeSpecifiedCreditorFinancialInstitution)"
             >Eine DiGA-Rechnung darf keine Informationen zur Bank des Kreditors enthalten.</assert>
         </rule>
     </pattern>

--- a/src/test/resources/dre0/xrechnung-1.2-richtig.xml
+++ b/src/test/resources/dre0/xrechnung-1.2-richtig.xml
@@ -83,8 +83,6 @@
                 <ram:ID>TEST_RECHNUNGSSTELLER</ram:ID>
                 <!-- IK des DiGA-Herstellers als "Seller Identifier" (BT-29) [BR-CO-26]: -->
                 <ram:ID schemeID="IK">987654321</ram:ID>
-                <!-- IK eines abweichenden Zahlungsempfängers als "Payee Identifier" (BT-60): -->
-                <ram:ID schemeID="IK_Zahlungsempfänger">987654322</ram:ID>
                 <ram:Name>Rechnungssteller</ram:Name>
                 <ram:DefinedTradeContact>
                     <ram:PersonName>Max Mustermann</ram:PersonName>
@@ -127,17 +125,12 @@
             </ram:ActualDeliverySupplyChainEvent>
         </ram:ApplicableHeaderTradeDelivery>
         <ram:ApplicableHeaderTradeSettlement>
+            <!-- IK des Zahlungsempfängers als "Payee Identifier" (BT-60), nur falls abweichend vom DiGA-Hersteller: -->
+            <ram:CreditorReferenceID schemeID="IK">987654322</ram:CreditorReferenceID>
             <ram:TaxCurrencyCode>EUR</ram:TaxCurrencyCode>
             <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
             <ram:SpecifiedTradeSettlementPaymentMeans>
                 <ram:TypeCode>30</ram:TypeCode>
-                <ram:PayeePartyCreditorFinancialAccount>
-                    <ram:IBANID>DE87123456781234567890</ram:IBANID>
-                    <ram:AccountName>Rechnungssteller</ram:AccountName>
-                </ram:PayeePartyCreditorFinancialAccount>
-                <ram:PayeeSpecifiedCreditorFinancialInstitution>
-                    <ram:BICID>DEUTSCHBANK</ram:BICID>
-                </ram:PayeeSpecifiedCreditorFinancialInstitution>
             </ram:SpecifiedTradeSettlementPaymentMeans>
             <ram:ApplicableTradeTax>
                 <ram:CalculatedAmount>19.00</ram:CalculatedAmount>

--- a/src/test/resources/dre0/xrechnung-1.2-richtig.xml
+++ b/src/test/resources/dre0/xrechnung-1.2-richtig.xml
@@ -83,6 +83,8 @@
                 <ram:ID>TEST_RECHNUNGSSTELLER</ram:ID>
                 <!-- IK des DiGA-Herstellers als "Seller Identifier" (BT-29) [BR-CO-26]: -->
                 <ram:ID schemeID="IK">987654321</ram:ID>
+                <!-- IK eines abweichenden Zahlungsempfängers als "Payee Identifier" (BT-60): -->
+                <ram:ID schemeID="IK_Zahlungsempfänger">987654322</ram:ID>
                 <ram:Name>Rechnungssteller</ram:Name>
                 <ram:DefinedTradeContact>
                     <ram:PersonName>Max Mustermann</ram:PersonName>

--- a/src/test/resources/dre0/xrechnung-2.0-richtig.xml
+++ b/src/test/resources/dre0/xrechnung-2.0-richtig.xml
@@ -83,8 +83,6 @@
                 <ram:ID>TEST_RECHNUNGSSTELLER</ram:ID>
                 <!-- IK des DiGA-Herstellers als "Seller Identifier" (BT-29) [BR-CO-26]: -->
                 <ram:ID schemeID="IK">987654321</ram:ID>
-                <!-- IK eines abweichenden Zahlungsempfängers als "Payee Identifier" (BT-60): -->
-                <ram:ID schemeID="IK_Zahlungsempfänger">987654322</ram:ID>
                 <ram:Name>Rechnungssteller</ram:Name>
                 <ram:DefinedTradeContact>
                     <ram:PersonName>Max Mustermann</ram:PersonName>

--- a/src/test/resources/dre0/xrechnung-2.0-richtig.xml
+++ b/src/test/resources/dre0/xrechnung-2.0-richtig.xml
@@ -127,17 +127,14 @@
             </ram:ActualDeliverySupplyChainEvent>
         </ram:ApplicableHeaderTradeDelivery>
         <ram:ApplicableHeaderTradeSettlement>
-<!--            <ram:TaxCurrencyCode>EUR</ram:TaxCurrencyCode>-->
+            <!-- IK des Zahlungsempfängers als "Payee Identifier" (BT-60), nur falls abweichend vom DiGA-Hersteller: -->
+            <ram:CreditorReferenceID schemeID="IK">987654322</ram:CreditorReferenceID>
+<!--
+            <ram:TaxCurrencyCode>EUR</ram:TaxCurrencyCode>
+-->
             <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
             <ram:SpecifiedTradeSettlementPaymentMeans>
                 <ram:TypeCode>30</ram:TypeCode>
-                <ram:PayeePartyCreditorFinancialAccount>
-                    <ram:IBANID>DE87123456781234567890</ram:IBANID>
-                    <ram:AccountName>Rechnungssteller</ram:AccountName>
-                </ram:PayeePartyCreditorFinancialAccount>
-                <ram:PayeeSpecifiedCreditorFinancialInstitution>
-                    <ram:BICID>DEUTSCHBANK</ram:BICID>
-                </ram:PayeeSpecifiedCreditorFinancialInstitution>
             </ram:SpecifiedTradeSettlementPaymentMeans>
             <ram:ApplicableTradeTax>
                 <ram:CalculatedAmount>19.00</ram:CalculatedAmount>

--- a/src/test/resources/dre0/xrechnung-2.0-richtig.xml
+++ b/src/test/resources/dre0/xrechnung-2.0-richtig.xml
@@ -83,6 +83,8 @@
                 <ram:ID>TEST_RECHNUNGSSTELLER</ram:ID>
                 <!-- IK des DiGA-Herstellers als "Seller Identifier" (BT-29) [BR-CO-26]: -->
                 <ram:ID schemeID="IK">987654321</ram:ID>
+                <!-- IK eines abweichenden Zahlungsempfängers als "Payee Identifier" (BT-60): -->
+                <ram:ID schemeID="IK_Zahlungsempfänger">987654322</ram:ID>
                 <ram:Name>Rechnungssteller</ram:Name>
                 <ram:DefinedTradeContact>
                     <ram:PersonName>Max Mustermann</ram:PersonName>


### PR DESCRIPTION
+ Allow optional `IK_Zahlungsempfänger`.
+ Require exactly one IBAN and one BIC.